### PR TITLE
Upload test reports as build artifacts on CI server.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,3 +20,10 @@ jobs:
       - run: yarn install --frozen-lockfile
       - run: yarn build
       - run: yarn test
+      - name: Upload test reports
+        uses: actions/upload-artifact@v2
+        with:
+          name: test-reports
+          path: |
+            examples/crawl-both/report
+            examples/crawl-both/tests/report


### PR DESCRIPTION
The test reports are now uploaded as build artifacts on CI so that I can see why the tests failed.